### PR TITLE
Implement HTTP server handlers and replace http_smol with embedded HTTP module

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,6 @@ authors = ["crjeder <crjeder@gmail.com>"]
 edition = "2021"
 
 [dependencies]
-generic_cocktail = {path = "../generic-cocktail", version = "0.1"}
 serde = {version = "1.0", features = ["derive"]}
 serde_json = "1.0"   # serialize json for drink recepies
 # embassy-net = "..."          # TODO: add correct version for target MCU

--- a/TODO.md
+++ b/TODO.md
@@ -1,8 +1,8 @@
 # TODO — CocktailBotHAL
 
-Open implementation work after the code cleanup. The cleanup removed all legacy
-Rocket 0.4 code and established the project structure around the async
-embassy-net server and HAL trait interface.
+Open implementation work. The handler stubs have been replaced with real
+implementations, `http_smol` has been replaced with `src/server/http.rs`,
+all API routes are wired, and `list_jobs()` has been added to `DispenseHal`.
 
 ---
 
@@ -14,23 +14,12 @@ The following crates are used in source files but not listed in `Cargo.toml`.
 Add correct versions for your target MCU platform:
 
 - `embassy-net` (used in `src/server/mod.rs`)
-- `embedded-io-async` (used in `src/server/mod.rs` and handler stubs)
-- `embassy_time` (used in `src/hal/mod.rs`)
+- `embedded-io-async` (used in `src/server/mod.rs`, `src/server/http.rs`,
+  and all handler modules)
+- `embassy_time` (used in `src/hal/mod.rs` and `src/server/handlers/dispense.rs`)
 
 Embassy crates are released together — pick a consistent snapshot compatible
 with your target (STM32, ESP32, RP2040, etc.).
-
-### `http_smol` crate
-
-`src/server/mod.rs` calls `http_smol::read_http_request` and
-`http_smol::write_json`. This crate is not in `Cargo.toml` and does not
-appear to be a published crate. Choose one approach:
-
-- **Option A**: Write `src/server/http.rs` implementing bare HTTP/1.1 request
-  parsing and JSON response writing directly with `embedded-io-async`.
-  Remove the `http_smol` references from `src/server/mod.rs`.
-- **Option B**: Find or publish a suitable `no_std` HTTP parsing crate
-  and add it as a dependency.
 
 ### Entry point: `no_std` + async executor
 
@@ -48,105 +37,25 @@ global allocator appropriate for your target.
 
 ---
 
-## Handler Implementations
+## Completed
 
-All six modules under `src/server/handlers/` contain only stubs.
-Implement each to match the contract in `API.yaml`.
+The following items have been implemented and are no longer open:
 
-### `status.rs` — GET /v1/status
-
-Call `hal.status.state()` and `hal.status.active_errors()`, serialize as:
-`{ "state": "<RobotState>", "errors": [...] }`, return HTTP 200.
-
-### `control.rs` — POST /v1/control/*
-
-- `handle_power`: parse `{ "on": bool }`, call `hal.control.power(on)`,
-  return 202 on success or error JSON on failure.
-- `handle_power_save`: parse `{ "enabled": bool }`, call
-  `hal.control.power_save(enabled)`.
-- `handle_reset`: call `hal.control.reset_errors()`.
-- `handle_reload_config`: call `hal.control.reload_config()`.
-- Wire `handle_power_save`, `handle_reset`, and `handle_reload_config` into
-  the route dispatch table in `src/server/mod.rs` (only `handle_power` is
-  currently dispatched).
-
-### `config.rs` — GET/PATCH /v1/config, GET/POST /v1/storage/config
-
-- `handle_config_get`: call `hal.config.get_active_config()`, serialize
-  `RobotConfig` as JSON. Wire into dispatch (currently missing).
-- `handle_config_patch`: deserialize `RobotConfig` from body, call
-  `hal.config.update_active_config(cfg)`.
-- `handle_storage_read`: call `hal.storage.load_storage_config()`, serialize.
-- `handle_storage_write`: deserialize config + overwrite flag, call
-  `hal.storage.store_storage_config(cfg, overwrite)`.
-
-### `sensors.rs` — GET /v1/sensors/*
-
-- `handle_glass`: call `hal.sensors.glass_state()`, serialize
-  `GlassSensorState` as JSON.
-- `handle_levels`: call `hal.sensors.level_state()`, serialize
-  `Vec<LevelState>` as JSON.
-- Wire both into `src/server/mod.rs` dispatch (currently neither is present).
-
-### `dispense.rs` — POST/GET /v1/dispense/jobs[/{job_id}]
-
-- `handle_create_job`: parse `JobCreateRequest` from body, call
-  `hal.dispense.create_job(...)`, return 202 with `{ "job_id": "..." }`.
-- `handle_list_jobs`: see design decision below.
-- `handle_job_status`: extract `job_id` from path, call
-  `hal.dispense.job_status(job_id)`.
-- `handle_cancel_job`: extract `job_id` from path, call
-  `hal.dispense.cancel_job(job_id)`.
-
-### `cleaning.rs` — POST /v1/cleaning/start|stop
-
-- `handle_start`: call `hal.cleaning.start_cleaning()`, return 202.
-- `handle_stop`: call `hal.cleaning.stop_cleaning()`, return 202. Wire into
-  `src/server/mod.rs` dispatch (currently missing).
-
----
-
-## Route Dispatch Gaps in `src/server/mod.rs`
-
-The following `API.yaml` routes are absent from the match block:
-
-| Method | Path                          | Handler                          |
-|--------|-------------------------------|----------------------------------|
-| POST   | /v1/control/power-save        | `control::handle_power_save`     |
-| POST   | /v1/control/reset             | `control::handle_reset`          |
-| POST   | /v1/control/reload-config     | `control::handle_reload_config`  |
-| GET    | /v1/config                    | `config::handle_config_get`      |
-| GET    | /v1/sensors/glass             | `sensors::handle_glass`          |
-| GET    | /v1/sensors/levels            | `sensors::handle_levels`         |
-| GET    | /v1/dispense/jobs/{job_id}    | `dispense::handle_job_status`    |
-| POST   | /v1/dispense/jobs/{job_id}    | `dispense::handle_cancel_job`    |
-| POST   | /v1/cleaning/stop             | `cleaning::handle_stop`          |
-| GET    | /v1/events                    | SSE handler (see below)          |
-
----
-
-## Path Parameter Routing
-
-The current `match (method, path)` in `src/server/mod.rs` cannot match
-`/v1/dispense/jobs/{job_id}` where `job_id` is a dynamic segment.
-Implement one approach before wiring those routes:
-
-- Simple prefix check: `path.starts_with("/v1/dispense/jobs/")` then extract
-  the tail as `job_id`.
-- A segment-based router if more complex parameters arise later.
-
----
-
-## `DispenseHal` — Missing `list_jobs` Method
-
-`GET /v1/dispense/jobs` is specified in `API.yaml` but there is no
-`list_jobs()` method on the `DispenseHal` trait. Decide and implement one
-approach before writing the handler:
-
-- Add `fn list_jobs(&self) -> Vec<JobStatus>` to `DispenseHal` in
-  `src/hal/mod.rs`, or
-- Maintain an internal job registry inside `ApiServer` that is updated by the
-  create/cancel handlers.
+- **`http_smol` replacement** — `src/server/http.rs` provides
+  `read_http_request()`, `write_json()`, `write_accepted()`,
+  `write_hal_error()`, and `parse_body()` using `embedded-io-async`.
+- **All handler implementations** — every handler in `src/server/handlers/`
+  now calls the corresponding HAL trait methods and writes proper HTTP
+  responses.
+- **Route dispatch** — all `API.yaml` routes (except SSE and auth) are wired
+  in `src/server/mod.rs`, including dynamic path extraction for
+  `/v1/dispense/jobs/{job_id}`.
+- **`DispenseHal::list_jobs()`** — added to the trait in `src/hal/mod.rs`
+  and stubbed in `main.rs`.
+- **Serde derives** — all HAL types now derive `Serialize` (and
+  `Deserialize` where needed) for JSON serialization.
+- **`generic_cocktail` dependency** — removed from `Cargo.toml` (no longer
+  used after legacy Rocket code removal).
 
 ---
 
@@ -156,25 +65,28 @@ approach before writing the handler:
 exists for it. Design the event model before implementing:
 
 - What events are emitted? (state changes, job completion, errors, etc.)
-- How does the HAL signal events? (callback registration, polling, async channel)
+- How does the HAL signal events? (callback registration, polling, async
+  channel)
 - SSE over raw embassy TCP sockets requires `text/event-stream` content type
   and chunked transfer encoding.
-
----
-
-## `StorageHal` Implementation
-
-No concrete implementation of `StorageHal` exists anywhere. Provide at minimum
-a RAM-backed stub that satisfies the trait for testing purposes, then replace
-with a real implementation (EEPROM, flash sector, SD card, etc.) for production.
 
 ---
 
 ## Authentication
 
 `API.yaml` declares Bearer token auth as a global security requirement.
-The server does not currently parse `Authorization` headers or validate tokens.
-Add token validation to `src/server/mod.rs` before dispatching to handlers.
+The server does not currently parse `Authorization` headers or validate
+tokens. Add token validation to `src/server/mod.rs` before dispatching to
+handlers.
+
+---
+
+## `StorageHal` Implementation
+
+No concrete implementation of `StorageHal` exists anywhere. Provide at
+minimum a RAM-backed stub that satisfies the trait for testing purposes,
+then replace with a real implementation (EEPROM, flash sector, SD card,
+etc.) for production.
 
 ---
 
@@ -183,8 +95,10 @@ Add token validation to `src/server/mod.rs` before dispatching to handlers.
 The following fields present in Rust types are missing from the `API.yaml`
 schemas:
 
-- `Config.part_ml` (`f32`) — present in `RobotConfig` but absent from schema
-- `Config.max_channels_per_job` (`u8`) — present in `RobotConfig` but absent
+- `Config.part_ml` (`f32`) — present in `RobotConfig` but absent from
+  schema
+- `Config.max_channels_per_job` (`u8`) — present in `RobotConfig` but
+  absent
 - `JobCreateRequest.require_glass` and `timeout` — parameters on
   `DispenseHal::create_job` but not in the request schema
 
@@ -195,17 +109,8 @@ schemas:
 No automated tests exist. To add them:
 
 1. Uncomment `test-case = "3.2"` in `[dev-dependencies]` in `Cargo.toml`.
-2. Uncomment `embedded-hal-mock = "0.7.2"` to create mock HAL implementations
-   for unit testing.
+2. Uncomment `embedded-hal-mock = "0.7.2"` to create mock HAL
+   implementations for unit testing.
 3. Add `#[cfg(test)]` modules to each handler file testing against mock HAL
    implementations.
 4. Add integration tests that send HTTP requests to a test server.
-
----
-
-## `generic_cocktail` Dependency
-
-The local path dependency `generic_cocktail` at `../generic-cocktail` was only
-used in the deleted legacy Rocket code. Evaluate whether it is still needed
-in the new async server layer. If not, remove it from `Cargo.toml` to
-eliminate the external path dependency requirement.

--- a/src/hal/mod.rs
+++ b/src/hal/mod.rs
@@ -3,9 +3,12 @@
 use alloc::string::String;
 use alloc::vec::Vec;
 use embassy_time::Duration;
+use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub enum RobotState {
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RobotState
+{
     Off,
     Booting,
     SelfTest,
@@ -17,44 +20,51 @@ pub enum RobotState {
     Error,
 }
 
-#[derive(Debug, Clone)]
-pub struct ErrorInfo {
+#[derive(Debug, Clone, Serialize)]
+pub struct ErrorInfo
+{
     pub code: String,
     pub message: String,
     pub hint: Option<String>,
     pub recoverable: bool,
 }
 
-#[derive(Debug, Clone)]
-pub struct LiquidCalibration {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiquidCalibration
+{
     pub ml_per_sec: f32,
     pub prime_ms: u32,
     pub viscosity_factor: f32,
 }
 
-#[derive(Debug, Clone)]
-pub struct LiquidConfig {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct LiquidConfig
+{
     pub id: String,
     pub name: String,
     pub position: u8,
     pub calibration: LiquidCalibration,
 }
 
-#[derive(Debug, Clone)]
-pub struct Capabilities {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Capabilities
+{
     pub level_reporting: LevelReporting,
     pub glass_typing: bool,
     pub simultaneous_channels: u8,
 }
 
-#[derive(Debug, Clone)]
-pub enum LevelReporting {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum LevelReporting
+{
     Binary,
     Decimal,
 }
 
-#[derive(Debug, Clone)]
-pub struct RobotConfig {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RobotConfig
+{
     pub version: String,
     pub liquids: Vec<LiquidConfig>,
     pub part_ml: f32,
@@ -63,27 +73,32 @@ pub struct RobotConfig {
     pub capabilities: Capabilities,
 }
 
-#[derive(Debug, Clone)]
-pub struct GlassSensorState {
+#[derive(Debug, Clone, Serialize)]
+pub struct GlassSensorState
+{
     pub present: bool,
     pub glass_type: Option<String>,
     pub confidence: f32,
 }
 
-#[derive(Debug, Clone)]
-pub enum LevelState {
+#[derive(Debug, Clone, Serialize)]
+#[serde(tag = "mode", rename_all = "snake_case")]
+pub enum LevelState
+{
     Binary { id: String, ok: bool },
     Decimal { id: String, remaining_ml: f32 },
 }
 
-#[derive(Debug, Clone)]
-pub struct JobItem {
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct JobItem
+{
     pub liquid_id: String,
     pub parts: u32,
 }
 
 #[derive(Debug, Clone)]
-pub enum JobState {
+pub enum JobState
+{
     Queued,
     Running,
     Done,
@@ -91,8 +106,30 @@ pub enum JobState {
     Error(String),
 }
 
-#[derive(Debug, Clone)]
-pub struct JobStatus {
+impl Serialize for JobState
+{
+    fn serialize<S: serde::Serializer>(
+        &self,
+        serializer: S,
+    ) -> Result<S::Ok, S::Error>
+    {
+        match self
+        {
+            JobState::Queued => serializer.serialize_str("queued"),
+            JobState::Running => serializer.serialize_str("running"),
+            JobState::Done => serializer.serialize_str("done"),
+            JobState::Cancelled =>
+            {
+                serializer.serialize_str("cancelled")
+            }
+            JobState::Error(_) => serializer.serialize_str("error"),
+        }
+    }
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct JobStatus
+{
     pub job_id: String,
     pub client_job_id: String,
     pub state: JobState,
@@ -147,6 +184,7 @@ pub trait DispenseHal {
         timeout: Duration,
     ) -> Result<String, ErrorInfo>; // returns job_id
 
+    fn list_jobs(&self) -> Vec<JobStatus>;
     fn job_status(&self, job_id: &str) -> Result<JobStatus, ErrorInfo>;
     fn cancel_job(&mut self, job_id: &str) -> Result<(), ErrorInfo>;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -109,6 +109,7 @@ impl DispenseHal for StubDispenseHal
     {
         todo!()
     }
+    fn list_jobs(&self) -> Vec<JobStatus> { vec![] }
     fn job_status(&self, _job_id: &str) -> Result<JobStatus, ErrorInfo>
     {
         todo!()

--- a/src/server/handlers/cleaning.rs
+++ b/src/server/handlers/cleaning.rs
@@ -1,24 +1,46 @@
 // src/server/handlers/cleaning.rs
 //
 // Handlers for POST /v1/cleaning/start and POST /v1/cleaning/stop
-//
-// TODO: Wire handle_stop into the route dispatch in src/server/mod.rs
-// (currently only handle_start is dispatched).
 
 use embedded_io_async::Write;
 
+use crate::server::http;
 use crate::server::RobotHal;
 
 /// POST /v1/cleaning/start — begin a cleaning program.
-/// TODO: Call hal.cleaning.start_cleaning(), return 202 or error JSON.
-pub async fn handle_start<W: Write + Unpin>(_hal: &mut RobotHal<'_>, _socket: &mut W)
+pub async fn handle_start<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement POST /v1/cleaning/start")
+    match hal.cleaning.start_cleaning()
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// POST /v1/cleaning/stop — stop a running cleaning program.
-/// TODO: Call hal.cleaning.stop_cleaning(), return 202 or error JSON.
-pub async fn handle_stop<W: Write + Unpin>(_hal: &mut RobotHal<'_>, _socket: &mut W)
+pub async fn handle_stop<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement POST /v1/cleaning/stop")
+    match hal.cleaning.stop_cleaning()
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }

--- a/src/server/handlers/config.rs
+++ b/src/server/handlers/config.rs
@@ -1,49 +1,146 @@
 // src/server/handlers/config.rs
 //
 // Handlers for GET/PATCH /v1/config and GET/POST /v1/storage/config
-//
-// TODO: Wire handle_config_get into the route dispatch in src/server/mod.rs
-// (currently only handle_config_patch, handle_storage_read, and
-// handle_storage_write are dispatched).
 
 use embedded_io_async::Write;
+use serde::Deserialize;
 
+use crate::hal::RobotConfig;
+use crate::server::http::{self, HttpRequest};
 use crate::server::RobotHal;
 
 /// GET /v1/config — return active (RAM) configuration.
-/// TODO: Call hal.config.get_active_config(), serialize RobotConfig as JSON.
-pub async fn handle_config_get<W: Write + Unpin>(_hal: &RobotHal<'_>, _socket: &mut W)
+pub async fn handle_config_get<W: Write + Unpin>(
+    hal: &RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement GET /v1/config")
+    let cfg = hal.config.get_active_config();
+    http::write_json(
+        socket,
+        200,
+        &serde_json::json!(cfg),
+    )
+    .await
+    .ok();
 }
 
 /// PATCH /v1/config — update active (RAM) configuration.
-/// TODO: Deserialize RobotConfig from body, call
-/// hal.config.update_active_config(cfg), return 200 or error JSON.
-pub async fn handle_config_patch<R, W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _request: R,
-    _socket: &mut W,
+pub async fn handle_config_patch<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    request: &HttpRequest,
+    socket: &mut W,
 )
 {
-    todo!("Implement PATCH /v1/config")
+    let cfg: RobotConfig = match http::parse_body(request)
+    {
+        Ok(c) => c,
+        Err(_) =>
+        {
+            http::write_json(
+                socket,
+                400,
+                &serde_json::json!({"error": "invalid request body"}),
+            )
+            .await
+            .ok();
+            return;
+        }
+    };
+
+    match hal.config.update_active_config(cfg)
+    {
+        Ok(()) =>
+        {
+            http::write_json(
+                socket,
+                200,
+                &serde_json::json!({"status": "updated"}),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// GET /v1/storage/config — read persistent configuration.
-/// TODO: Call hal.storage.load_storage_config(), serialize result as JSON.
-pub async fn handle_storage_read<W: Write + Unpin>(_hal: &RobotHal<'_>, _socket: &mut W)
+pub async fn handle_storage_read<W: Write + Unpin>(
+    hal: &RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement GET /v1/storage/config")
+    match hal.storage.load_storage_config()
+    {
+        Ok(cfg) =>
+        {
+            http::write_json(
+                socket,
+                200,
+                &serde_json::json!({"data": cfg}),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// POST /v1/storage/config — write persistent configuration.
-/// TODO: Deserialize RobotConfig and overwrite flag from body, call
-/// hal.storage.store_storage_config(cfg, overwrite), return 200 or error.
-pub async fn handle_storage_write<R, W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _request: R,
-    _socket: &mut W,
+/// Body: `{ "data": <RobotConfig>, "overwrite": bool }`
+pub async fn handle_storage_write<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    request: &HttpRequest,
+    socket: &mut W,
 )
 {
-    todo!("Implement POST /v1/storage/config")
+    #[derive(Deserialize)]
+    struct Body
+    {
+        data: RobotConfig,
+        #[serde(default)]
+        overwrite: bool,
+    }
+
+    let body: Body = match http::parse_body(request)
+    {
+        Ok(b) => b,
+        Err(_) =>
+        {
+            http::write_json(
+                socket,
+                400,
+                &serde_json::json!({"error": "invalid request body"}),
+            )
+            .await
+            .ok();
+            return;
+        }
+    };
+
+    match hal
+        .storage
+        .store_storage_config(body.data, body.overwrite)
+    {
+        Ok(()) =>
+        {
+            http::write_json(
+                socket,
+                200,
+                &serde_json::json!({"success": true}),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }

--- a/src/server/handlers/control.rs
+++ b/src/server/handlers/control.rs
@@ -1,52 +1,134 @@
 // src/server/handlers/control.rs
 //
 // Handlers for POST /v1/control/*
-//
-// TODO: Implement each handler. Wire handle_power_save, handle_reset, and
-// handle_reload_config into the route dispatch in src/server/mod.rs
-// (currently only handle_power is dispatched).
 
 use embedded_io_async::Write;
+use serde::Deserialize;
 
+use crate::server::http::{self, HttpRequest};
 use crate::server::RobotHal;
 
 /// POST /v1/control/power — power the robot on or off.
-/// Body: { "on": bool }
-/// TODO: Parse body, call hal.control.power(on), return 202 or error JSON.
-pub async fn handle_power<R, W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _request: R,
-    _socket: &mut W,
+/// Body: `{ "on": bool }`
+pub async fn handle_power<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    request: &HttpRequest,
+    socket: &mut W,
 )
 {
-    todo!("Implement POST /v1/control/power")
+    #[derive(Deserialize)]
+    struct Body
+    {
+        on: bool,
+    }
+
+    let body: Body = match http::parse_body(request)
+    {
+        Ok(b) => b,
+        Err(_) =>
+        {
+            http::write_json(
+                socket,
+                400,
+                &serde_json::json!({"error": "invalid request body"}),
+            )
+            .await
+            .ok();
+            return;
+        }
+    };
+
+    match hal.control.power(body.on)
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// POST /v1/control/power-save — enter or exit power-save mode.
-/// Body: { "enabled": bool }
-/// TODO: Parse body, call hal.control.power_save(enabled), return 202.
-pub async fn handle_power_save<R, W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _request: R,
-    _socket: &mut W,
+/// Body: `{ "enabled": bool }`
+pub async fn handle_power_save<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    request: &HttpRequest,
+    socket: &mut W,
 )
 {
-    todo!("Implement POST /v1/control/power-save")
+    #[derive(Deserialize)]
+    struct Body
+    {
+        enabled: bool,
+    }
+
+    let body: Body = match http::parse_body(request)
+    {
+        Ok(b) => b,
+        Err(_) =>
+        {
+            http::write_json(
+                socket,
+                400,
+                &serde_json::json!({"error": "invalid request body"}),
+            )
+            .await
+            .ok();
+            return;
+        }
+    };
+
+    match hal.control.power_save(body.enabled)
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// POST /v1/control/reset — clear errors and return to idle.
-/// TODO: Call hal.control.reset_errors(), return 202 or error JSON.
-pub async fn handle_reset<W: Write + Unpin>(_hal: &mut RobotHal<'_>, _socket: &mut W)
-{
-    todo!("Implement POST /v1/control/reset")
-}
-
-/// POST /v1/control/reload-config — reload config from persistent storage.
-/// TODO: Call hal.control.reload_config(), return 202 or error JSON.
-pub async fn handle_reload_config<W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _socket: &mut W,
+pub async fn handle_reset<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    socket: &mut W,
 )
 {
-    todo!("Implement POST /v1/control/reload-config")
+    match hal.control.reset_errors()
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
+}
+
+/// POST /v1/control/reload-config — reload config from persistent
+/// storage.
+pub async fn handle_reload_config<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    socket: &mut W,
+)
+{
+    match hal.control.reload_config()
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }

--- a/src/server/handlers/dispense.rs
+++ b/src/server/handlers/dispense.rs
@@ -1,57 +1,145 @@
 // src/server/handlers/dispense.rs
 //
-// Handlers for POST/GET /v1/dispense/jobs and /v1/dispense/jobs/{job_id}
-//
-// TODO: Wire handle_job_status and handle_cancel_job into the route dispatch
-// in src/server/mod.rs. Note: these require path parameter extraction —
-// see TODO.md for the routing design decision.
+// Handlers for POST/GET /v1/dispense/jobs and
+// GET/POST /v1/dispense/jobs/{job_id}
 
+use alloc::string::String;
+use alloc::vec::Vec;
 use embedded_io_async::Write;
+use embassy_time::Duration;
+use serde::Deserialize;
 
+use crate::hal::JobItem;
+use crate::server::http::{self, HttpRequest};
 use crate::server::RobotHal;
 
+/// Default job timeout (30 seconds) when not specified in the
+/// request.
+const DEFAULT_TIMEOUT_MS: u64 = 30_000;
+
 /// POST /v1/dispense/jobs — create and queue a new dispensing job.
-/// Body: JobCreateRequest (liquid_id, parts, require_glass, timeout, ...)
-/// TODO: Parse body, call hal.dispense.create_job(...), return 202 with
-/// { "job_id": "..." } or error JSON.
-pub async fn handle_create_job<R, W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _request: R,
-    _socket: &mut W,
+pub async fn handle_create_job<W: Write + Unpin>(
+    hal: &mut RobotHal<'_>,
+    request: &HttpRequest,
+    socket: &mut W,
 )
 {
-    todo!("Implement POST /v1/dispense/jobs")
+    #[derive(Deserialize)]
+    struct Body
+    {
+        client_job_id: String,
+        items: Vec<JobItem>,
+        #[serde(default)]
+        require_glass: bool,
+        #[serde(default)]
+        parallel: bool,
+        #[serde(default)]
+        timeout_ms: Option<u64>,
+    }
+
+    let body: Body = match http::parse_body(request)
+    {
+        Ok(b) => b,
+        Err(_) =>
+        {
+            http::write_json(
+                socket,
+                400,
+                &serde_json::json!({"error": "invalid request body"}),
+            )
+            .await
+            .ok();
+            return;
+        }
+    };
+
+    let timeout = Duration::from_millis(
+        body.timeout_ms.unwrap_or(DEFAULT_TIMEOUT_MS),
+    );
+
+    match hal.dispense.create_job(
+        body.client_job_id,
+        body.items,
+        body.require_glass,
+        body.parallel,
+        timeout,
+    )
+    {
+        Ok(job_id) =>
+        {
+            http::write_json(
+                socket,
+                202,
+                &serde_json::json!({"job_id": job_id}),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// GET /v1/dispense/jobs — list job queue and history.
-/// TODO: Requires a design decision — DispenseHal has no list_jobs() method.
-/// Either add it to the trait in src/hal/mod.rs, or maintain a job registry
-/// in ApiServer. See TODO.md for details.
-pub async fn handle_list_jobs<W: Write + Unpin>(_hal: &RobotHal<'_>, _socket: &mut W)
+pub async fn handle_list_jobs<W: Write + Unpin>(
+    hal: &RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement GET /v1/dispense/jobs — requires list_jobs() design decision")
+    let jobs = hal.dispense.list_jobs();
+    http::write_json(
+        socket,
+        200,
+        &serde_json::json!(jobs),
+    )
+    .await
+    .ok();
 }
 
 /// GET /v1/dispense/jobs/{job_id} — job status with progress.
-/// TODO: Extract job_id from path, call hal.dispense.job_status(job_id),
-/// serialize JobStatus as JSON.
 pub async fn handle_job_status<W: Write + Unpin>(
-    _hal: &RobotHal<'_>,
-    _job_id: &str,
-    _socket: &mut W,
+    hal: &RobotHal<'_>,
+    job_id: &str,
+    socket: &mut W,
 )
 {
-    todo!("Implement GET /v1/dispense/jobs/{{job_id}}")
+    match hal.dispense.job_status(job_id)
+    {
+        Ok(status) =>
+        {
+            http::write_json(
+                socket,
+                200,
+                &serde_json::json!(status),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// POST /v1/dispense/jobs/{job_id} — cancel a job.
-/// TODO: Extract job_id from path, call hal.dispense.cancel_job(job_id),
-/// return 202 or error JSON.
 pub async fn handle_cancel_job<W: Write + Unpin>(
-    _hal: &mut RobotHal<'_>,
-    _job_id: &str,
-    _socket: &mut W,
+    hal: &mut RobotHal<'_>,
+    job_id: &str,
+    socket: &mut W,
 )
 {
-    todo!("Implement POST /v1/dispense/jobs/{{job_id}} (cancel)")
+    match hal.dispense.cancel_job(job_id)
+    {
+        Ok(()) =>
+        {
+            http::write_accepted(socket).await.ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }

--- a/src/server/handlers/sensors.rs
+++ b/src/server/handlers/sensors.rs
@@ -1,27 +1,58 @@
 // src/server/handlers/sensors.rs
 //
 // Handlers for GET /v1/sensors/glass and GET /v1/sensors/levels
-//
-// TODO: Wire both handlers into the route dispatch in src/server/mod.rs
-// (currently neither sensors route is dispatched).
 
 use embedded_io_async::Write;
 
+use crate::server::http;
 use crate::server::RobotHal;
 
 /// GET /v1/sensors/glass — glass presence and type detection.
-/// TODO: Call hal.sensors.glass_state(), serialize GlassSensorState as JSON.
-/// Response schema: { "present": bool, "glass_type": string|null,
-///                    "confidence": float }
-pub async fn handle_glass<W: Write + Unpin>(_hal: &RobotHal<'_>, _socket: &mut W)
+pub async fn handle_glass<W: Write + Unpin>(
+    hal: &RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement GET /v1/sensors/glass")
+    match hal.sensors.glass_state()
+    {
+        Ok(state) =>
+        {
+            http::write_json(
+                socket,
+                200,
+                &serde_json::json!(state),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }
 
 /// GET /v1/sensors/levels — liquid level readings for all channels.
-/// TODO: Call hal.sensors.level_state(), serialize Vec<LevelState> as JSON.
-/// Each entry is either Binary { id, ok } or Decimal { id, remaining_ml }.
-pub async fn handle_levels<W: Write + Unpin>(_hal: &RobotHal<'_>, _socket: &mut W)
+pub async fn handle_levels<W: Write + Unpin>(
+    hal: &RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement GET /v1/sensors/levels")
+    match hal.sensors.level_state()
+    {
+        Ok(levels) =>
+        {
+            http::write_json(
+                socket,
+                200,
+                &serde_json::json!(levels),
+            )
+            .await
+            .ok();
+        }
+        Err(e) =>
+        {
+            http::write_hal_error(socket, &e).await.ok();
+        }
+    }
 }

--- a/src/server/handlers/status.rs
+++ b/src/server/handlers/status.rs
@@ -1,17 +1,31 @@
 // src/server/handlers/status.rs
 //
 // Handler for GET /v1/status
-//
-// TODO: Call hal.status.state() and hal.status.active_errors(), serialize
-// both as JSON, and write an HTTP 200 response to the socket.
-// Response schema: { "state": "<RobotState>", "errors": [...] }
 
 use embedded_io_async::Write;
 
+use crate::server::http;
 use crate::server::RobotHal;
 
 /// GET /v1/status — return current robot state and active errors.
-pub async fn handle_status<W: Write + Unpin>(_hal: &RobotHal<'_>, _socket: &mut W)
+///
+/// Response: `{ "state": "<RobotState>", "errors": [...] }`
+pub async fn handle_status<W: Write + Unpin>(
+    hal: &RobotHal<'_>,
+    socket: &mut W,
+)
 {
-    todo!("Implement GET /v1/status")
+    let state = hal.status.state();
+    let errors = hal.status.active_errors();
+
+    http::write_json(
+        socket,
+        200,
+        &serde_json::json!({
+            "state": state,
+            "errors": errors,
+        }),
+    )
+    .await
+    .ok();
 }

--- a/src/server/http.rs
+++ b/src/server/http.rs
@@ -1,0 +1,227 @@
+// src/server/http.rs
+//
+// Minimal HTTP/1.1 request parser and JSON response writer for
+// embedded-io-async sockets. Replaces the non-existent `http_smol`
+// crate that was referenced in earlier code.
+
+use alloc::format;
+use alloc::string::String;
+use alloc::vec::Vec;
+use embedded_io_async::{Read, Write};
+
+use crate::hal::ErrorInfo;
+
+/// Maximum header size accepted (4 KiB).
+const MAX_HEADER_BYTES: usize = 4096;
+
+// =========================================================================
+// Types
+// =========================================================================
+
+/// A parsed HTTP/1.1 request.
+pub struct HttpRequest
+{
+    pub method: String,
+    pub path: String,
+    pub body: Vec<u8>,
+}
+
+/// Errors that can occur during HTTP I/O.
+#[derive(Debug)]
+pub enum HttpError
+{
+    ReadFailed,
+    WriteFailed,
+    ConnectionClosed,
+    HeadersTooLarge,
+    InvalidUtf8,
+    MalformedRequest,
+    SerializeFailed,
+    DeserializeFailed,
+}
+
+// =========================================================================
+// Request parsing
+// =========================================================================
+
+/// Read a complete HTTP/1.1 request (headers + body) from `socket`.
+pub async fn read_http_request<S: Read + Unpin>(
+    socket: &mut S,
+) -> Result<HttpRequest, HttpError>
+{
+    let mut buf = Vec::new();
+    let mut byte = [0u8; 1];
+
+    // Read until the end-of-headers marker (\r\n\r\n).
+    loop
+    {
+        let n = socket
+            .read(&mut byte)
+            .await
+            .map_err(|_| HttpError::ReadFailed)?;
+        if n == 0
+        {
+            return Err(HttpError::ConnectionClosed);
+        }
+        buf.push(byte[0]);
+        if buf.len() >= 4
+            && buf[buf.len() - 4..] == *b"\r\n\r\n"
+        {
+            break;
+        }
+        if buf.len() > MAX_HEADER_BYTES
+        {
+            return Err(HttpError::HeadersTooLarge);
+        }
+    }
+
+    let header_str = core::str::from_utf8(&buf)
+        .map_err(|_| HttpError::InvalidUtf8)?;
+
+    // Parse request line: METHOD PATH HTTP/1.x
+    let request_line = header_str
+        .lines()
+        .next()
+        .ok_or(HttpError::MalformedRequest)?;
+    let mut parts = request_line.split_whitespace();
+    let method: String = parts
+        .next()
+        .ok_or(HttpError::MalformedRequest)?
+        .into();
+    let path: String = parts
+        .next()
+        .ok_or(HttpError::MalformedRequest)?
+        .into();
+
+    // Find Content-Length header (case-insensitive).
+    let mut content_length: usize = 0;
+    for line in header_str.lines().skip(1)
+    {
+        if line.len() > 16
+            && line[..15].eq_ignore_ascii_case("content-length:")
+        {
+            content_length =
+                line[15..].trim().parse().unwrap_or(0);
+        }
+    }
+
+    // Read body.
+    let mut body = Vec::new();
+    if content_length > 0
+    {
+        body.resize(content_length, 0);
+        let mut read = 0;
+        while read < content_length
+        {
+            let n = socket
+                .read(&mut body[read..])
+                .await
+                .map_err(|_| HttpError::ReadFailed)?;
+            if n == 0
+            {
+                break;
+            }
+            read += n;
+        }
+        body.truncate(read);
+    }
+
+    Ok(HttpRequest { method, path, body })
+}
+
+// =========================================================================
+// Response writing
+// =========================================================================
+
+/// Write an HTTP response with a JSON body.
+pub async fn write_json<S: Write + Unpin>(
+    socket: &mut S,
+    status: u16,
+    body: &serde_json::Value,
+) -> Result<(), HttpError>
+{
+    let body_bytes = serde_json::to_vec(body)
+        .map_err(|_| HttpError::SerializeFailed)?;
+    let status_text = status_reason(status);
+    let header = format!(
+        "HTTP/1.1 {} {}\r\n\
+         Content-Type: application/json\r\n\
+         Content-Length: {}\r\n\
+         Connection: close\r\n\r\n",
+        status,
+        status_text,
+        body_bytes.len()
+    );
+
+    socket
+        .write_all(header.as_bytes())
+        .await
+        .map_err(|_| HttpError::WriteFailed)?;
+    socket
+        .write_all(&body_bytes)
+        .await
+        .map_err(|_| HttpError::WriteFailed)?;
+    Ok(())
+}
+
+/// Write an HTTP 202 Accepted response with a simple JSON body.
+pub async fn write_accepted<S: Write + Unpin>(
+    socket: &mut S,
+) -> Result<(), HttpError>
+{
+    write_json(
+        socket,
+        202,
+        &serde_json::json!({"status": "accepted"}),
+    )
+    .await
+}
+
+/// Write an error response derived from a HAL `ErrorInfo`.
+pub async fn write_hal_error<S: Write + Unpin>(
+    socket: &mut S,
+    err: &ErrorInfo,
+) -> Result<(), HttpError>
+{
+    write_json(
+        socket,
+        500,
+        &serde_json::json!({
+            "error": {
+                "code": err.code,
+                "message": err.message,
+                "hint": err.hint,
+                "recoverable": err.recoverable,
+            }
+        }),
+    )
+    .await
+}
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+/// Deserialize a JSON body from an `HttpRequest`.
+pub fn parse_body<T: serde::de::DeserializeOwned>(
+    request: &HttpRequest,
+) -> Result<T, HttpError>
+{
+    serde_json::from_slice(&request.body)
+        .map_err(|_| HttpError::DeserializeFailed)
+}
+
+/// Map HTTP status codes to reason phrases.
+fn status_reason(code: u16) -> &'static str
+{
+    match code
+    {
+        200 => "OK",
+        202 => "Accepted",
+        400 => "Bad Request",
+        404 => "Not Found",
+        405 => "Method Not Allowed",
+        500 => "Internal Server Error",
+        _ => "OK",
+    }
+}

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -1,10 +1,14 @@
 // src/server/mod.rs
 
 use embassy_net::tcp::TcpSocket;
-use embedded_io_async::Write;
+use embedded_io_async::{Read, Write};
+
 use crate::hal::*;
 
-pub struct RobotHal<'a> {
+pub mod http;
+
+pub struct RobotHal<'a>
+{
     pub control: &'a mut dyn ControlHal,
     pub status: &'a mut dyn StatusHal,
     pub config: &'a mut dyn ConfigHal,
@@ -14,14 +18,21 @@ pub struct RobotHal<'a> {
     pub cleaning: &'a mut dyn CleaningHal,
 }
 
-pub struct ApiServer<'a> {
+pub struct ApiServer<'a>
+{
     pub hal: RobotHal<'a>,
 }
 
-impl<'a> ApiServer<'a> {
-    /// Hauptserver-Loop
-    pub async fn run(&mut self, net_stack: embassy_net::Stack<'_>) {
-        loop {
+impl<'a> ApiServer<'a>
+{
+    /// Main server loop — accepts connections on port 80.
+    pub async fn run(
+        &mut self,
+        net_stack: embassy_net::Stack<'_>,
+    )
+    {
+        loop
+        {
             let mut socket = TcpSocket::new(&net_stack);
             socket.accept(80).await.unwrap();
 
@@ -29,63 +40,214 @@ impl<'a> ApiServer<'a> {
         }
     }
 
-    async fn handle_connection<W: Write + Unpin>(&mut self, socket: &mut W) {
-        let request = http_smol::read_http_request(socket).await.unwrap();
+    async fn handle_connection<S: Read + Write + Unpin>(
+        &mut self,
+        socket: &mut S,
+    )
+    {
+        let request =
+            match http::read_http_request(socket).await
+            {
+                Ok(r) => r,
+                Err(_) => return,
+            };
+
+        let method = request.method.as_str();
         let path = request.path.as_str();
 
-        match (request.method.as_str(), path) {
-            ("GET", "/v1/status") => {
-                handlers::status::handle_status(&self.hal, socket).await;
-            }
-
-            ("POST", "/v1/control/power") => {
-                handlers::control::handle_power(&mut self.hal, request, socket).await;
-            }
-
-            ("PATCH", "/v1/config") => {
-                handlers::config::handle_config_patch(&mut self.hal, request, socket).await;
-            }
-
-            ("GET", "/v1/storage/config") => {
-                handlers::config::handle_storage_read(&self.hal, socket).await;
-            }
-
-            ("POST", "/v1/storage/config") => {
-                handlers::config::handle_storage_write(&mut self.hal, request, socket).await;
-            }
-
-            ("POST", "/v1/dispense/jobs") => {
-                handlers::dispense::handle_create_job(&mut self.hal, request, socket).await;
-            }
-
-            ("GET", "/v1/dispense/jobs") => {
-                handlers::dispense::handle_list_jobs(&self.hal, socket).await;
-            }
-
-            ("POST", "/v1/cleaning/start") => {
-                handlers::cleaning::handle_start(&mut self.hal, socket).await;
-            }
-
-            // TODO: weitere Endpunkte 1:1 nach OpenAPI
-
-            _ => {
-                http_smol::write_json(
-                    socket,
-                    404,
-                    &serde_json::json!({ "error": "not found" }),
+        match (method, path)
+        {
+            // ----- status -----
+            ("GET", "/v1/status") =>
+            {
+                handlers::status::handle_status(
+                    &self.hal, socket,
                 )
-                .await
-                .ok();
+                .await;
+            }
+
+            // ----- control -----
+            ("POST", "/v1/control/power") =>
+            {
+                handlers::control::handle_power(
+                    &mut self.hal,
+                    &request,
+                    socket,
+                )
+                .await;
+            }
+            ("POST", "/v1/control/power-save") =>
+            {
+                handlers::control::handle_power_save(
+                    &mut self.hal,
+                    &request,
+                    socket,
+                )
+                .await;
+            }
+            ("POST", "/v1/control/reset") =>
+            {
+                handlers::control::handle_reset(
+                    &mut self.hal,
+                    socket,
+                )
+                .await;
+            }
+            ("POST", "/v1/control/reload-config") =>
+            {
+                handlers::control::handle_reload_config(
+                    &mut self.hal,
+                    socket,
+                )
+                .await;
+            }
+
+            // ----- config -----
+            ("GET", "/v1/config") =>
+            {
+                handlers::config::handle_config_get(
+                    &self.hal, socket,
+                )
+                .await;
+            }
+            ("PATCH", "/v1/config") =>
+            {
+                handlers::config::handle_config_patch(
+                    &mut self.hal,
+                    &request,
+                    socket,
+                )
+                .await;
+            }
+
+            // ----- storage -----
+            ("GET", "/v1/storage/config") =>
+            {
+                handlers::config::handle_storage_read(
+                    &self.hal, socket,
+                )
+                .await;
+            }
+            ("POST", "/v1/storage/config") =>
+            {
+                handlers::config::handle_storage_write(
+                    &mut self.hal,
+                    &request,
+                    socket,
+                )
+                .await;
+            }
+
+            // ----- sensors -----
+            ("GET", "/v1/sensors/glass") =>
+            {
+                handlers::sensors::handle_glass(
+                    &self.hal, socket,
+                )
+                .await;
+            }
+            ("GET", "/v1/sensors/levels") =>
+            {
+                handlers::sensors::handle_levels(
+                    &self.hal, socket,
+                )
+                .await;
+            }
+
+            // ----- dispense (collection) -----
+            ("POST", "/v1/dispense/jobs") =>
+            {
+                handlers::dispense::handle_create_job(
+                    &mut self.hal,
+                    &request,
+                    socket,
+                )
+                .await;
+            }
+            ("GET", "/v1/dispense/jobs") =>
+            {
+                handlers::dispense::handle_list_jobs(
+                    &self.hal, socket,
+                )
+                .await;
+            }
+
+            // ----- cleaning -----
+            ("POST", "/v1/cleaning/start") =>
+            {
+                handlers::cleaning::handle_start(
+                    &mut self.hal,
+                    socket,
+                )
+                .await;
+            }
+            ("POST", "/v1/cleaning/stop") =>
+            {
+                handlers::cleaning::handle_stop(
+                    &mut self.hal,
+                    socket,
+                )
+                .await;
+            }
+
+            // ----- dynamic paths & fallback -----
+            _ =>
+            {
+                // /v1/dispense/jobs/{job_id}
+                if let Some(job_id) =
+                    path.strip_prefix("/v1/dispense/jobs/")
+                {
+                    match method
+                    {
+                        "GET" =>
+                        {
+                            handlers::dispense::handle_job_status(
+                                &self.hal, job_id, socket,
+                            )
+                            .await;
+                        }
+                        "POST" =>
+                        {
+                            handlers::dispense::handle_cancel_job(
+                                &mut self.hal,
+                                job_id,
+                                socket,
+                            )
+                            .await;
+                        }
+                        _ =>
+                        {
+                            http::write_json(
+                                socket,
+                                405,
+                                &serde_json::json!({"error": "method not allowed"}),
+                            )
+                            .await
+                            .ok();
+                        }
+                    }
+                }
+                else
+                {
+                    http::write_json(
+                        socket,
+                        404,
+                        &serde_json::json!({"error": "not found"}),
+                    )
+                    .await
+                    .ok();
+                }
             }
         }
     }
 }
 
-pub mod handlers {
-    pub mod status;
-    pub mod control;
-    pub mod config;
-    pub mod sensors;
-    pub mod dispense;
+pub mod handlers
+{
     pub mod cleaning;
+    pub mod config;
+    pub mod control;
+    pub mod dispense;
+    pub mod sensors;
+    pub mod status;
 }


### PR DESCRIPTION
## Summary

This PR completes the HTTP API server implementation by:
1. Creating a new `src/server/http.rs` module that replaces the non-existent `http_smol` crate with a minimal HTTP/1.1 request parser and JSON response writer using `embedded-io-async`
2. Implementing all handler stubs in `src/server/handlers/` to call corresponding HAL trait methods
3. Wiring all API routes (from `API.yaml`) into the dispatch table in `src/server/mod.rs`, including dynamic path parameter extraction
4. Adding `list_jobs()` method to the `DispenseHal` trait and implementing it in the stub

## Key Changes

### New HTTP Module (`src/server/http.rs`)
- Implements `read_http_request()` for parsing HTTP/1.1 requests with headers and body
- Provides `write_json()`, `write_accepted()`, and `write_hal_error()` for HTTP responses
- Includes `parse_body()` helper for deserializing JSON request bodies
- Handles Content-Length parsing and proper HTTP status reason phrases
- Replaces all references to the non-existent `http_smol` crate

### Handler Implementations
All six handler modules now contain complete implementations:
- **`status.rs`**: Calls `hal.status.state()` and `hal.status.active_errors()`, returns HTTP 200
- **`control.rs`**: Implements power, power-save, reset, and reload-config handlers with JSON body parsing
- **`config.rs`**: Implements get/patch active config and storage read/write with proper error handling
- **`sensors.rs`**: Implements glass state and level readings endpoints
- **`dispense.rs`**: Implements job creation, listing, status, and cancellation with timeout support
- **`cleaning.rs`**: Implements start and stop cleaning handlers

### Route Dispatch (`src/server/mod.rs`)
- Added all missing routes from `API.yaml` (power-save, reset, reload-config, config GET, sensors, cleaning stop)
- Implemented dynamic path parameter extraction for `/v1/dispense/jobs/{job_id}` using prefix matching
- Organized routes with section comments for clarity
- Changed socket trait bound from `Write` to `Read + Write` to support request parsing
- Improved error handling with proper HTTP status codes (400, 404, 405, 500)

### HAL Updates (`src/hal/mod.rs`)
- Added `Serialize`/`Deserialize` derives to all public types for JSON support
- Added custom `Serialize` impl for `JobState` enum to use string representations
- Added `list_jobs()` method to `DispenseHal` trait
- Implemented `list_jobs()` stub in `StubDispenseHal`

### Code Quality
- Consistent formatting with opening braces on new lines
- Comprehensive error handling with `write_hal_error()` for HAL failures
- Proper HTTP semantics (202 Accepted for async operations, 200 for reads, 404/405 for routing)
- Updated TODO.md to reflect completed work

## Notable Implementation Details

- Default job timeout of 30 seconds when not specified in requests
- Content-Length header parsing for request body size determination
- Case-insensitive header matching for HTTP compliance
- Graceful fallback to 404 for unmatched routes
- All handlers use `&HttpRequest` reference instead of generic type parameter for consistency

https://claude.ai/code/session_01PmUeqgCDcuipDPCLjtWQo7